### PR TITLE
feat: email collection and account-recovery

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "split-webapp",
-  "version": "0.0.212",
+  "version": "0.0.213",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "split-webapp",
-      "version": "0.0.212",
+      "version": "0.0.213",
       "dependencies": {
         "@lexical/react": "^0.27.2",
         "@preact/signals-react": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "split-webapp",
   "private": true,
-  "version": "0.0.212",
+  "version": "0.0.213",
   "tagVersionPrefix": "",
   "type": "module",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import RedirectToBudget from './routes/RedirectToBudget';
 import RedirectToNonGroupExpenses from './routes/RedirectToNonGroupExpenses';
 import Protected from './pages/Protected/Protected';
 import CreateAccount from './pages/CreateAccount/CreateAccount';
+import ResetPassword from './pages/ResetPassword/ResetPassword';
 import Spinner from './components/Spinner/Spinner';
 import { PwaInstallPrompt } from './components/PwaInstallPrompt/PwaInstallPrompt';
 import {
@@ -56,6 +57,7 @@ const App = () => {
             <Route path={routes.AUTH} element={<Auth />} />
             <Route path={routes.CREATE} element={<CreateAccount />} />
             <Route path={routes.GOOGLE_REDIRECT} element={<GoogleCallback />} />
+            <Route path={routes.RESET_PASSWORD} element={<ResetPassword />} />
             <Route element={<Protected />}>
               <Route path={routes.ROOT} element={<Home />} />
               <Route path={routes.JOIN} element={<Home />} />

--- a/src/api/auth/api.ts
+++ b/src/api/auth/api.ts
@@ -2,9 +2,14 @@ import {
   PasswordSignInRequest,
   PasswordSignUpRequest,
   RefreshTokenResponse,
+  RequestPasswordResetRequest,
+  RequestUsernameRecoveryRequest,
+  ResetPasswordRequest,
   SendGoogleCodeRequest,
+  SetAccountEmailRequest,
+  VerifyAccountEmailRequest,
 } from '../../types';
-import { authApiClient } from '../apiClients';
+import { apiClient, authApiClient } from '../apiClients';
 
 export const sendGoogleAccessToken = async (request: SendGoogleCodeRequest) => {
   const response = await authApiClient.post<SendGoogleCodeRequest, any>(
@@ -25,6 +30,37 @@ export const createPasswordCredentials = async (
   request: PasswordSignUpRequest
 ) => {
   const response = await authApiClient.post('/auth/password/sign-up', request);
+  return response.data;
+};
+
+export const requestPasswordReset = async (
+  request: RequestPasswordResetRequest
+) => {
+  const response = await authApiClient.post('/auth/password/forgot', request);
+  return response.data;
+};
+
+export const resetPassword = async (request: ResetPasswordRequest) => {
+  const response = await authApiClient.post('/auth/password/reset', request);
+  return response.data;
+};
+
+export const requestUsernameRecovery = async (
+  request: RequestUsernameRecoveryRequest
+) => {
+  const response = await authApiClient.post('/auth/username/forgot', request);
+  return response.data;
+};
+
+export const setAccountEmail = async (request: SetAccountEmailRequest) => {
+  const response = await apiClient.post('/auth/account/email', request);
+  return response.data;
+};
+
+export const verifyAccountEmail = async (
+  request: VerifyAccountEmailRequest
+) => {
+  const response = await apiClient.post('/auth/account/email/verify', request);
   return response.data;
 };
 

--- a/src/components/Animations/EditEmailAnimation.tsx
+++ b/src/components/Animations/EditEmailAnimation.tsx
@@ -1,0 +1,33 @@
+import { CSSTransition } from 'react-transition-group';
+import { useRef } from 'react';
+import { Signal } from '@preact/signals-react';
+import EditEmail from '../Menus/EditEmail/EditEmail';
+
+interface EditEmailAnimationProps {
+  editEmailMenu: Signal<string | null>;
+  existingEmail: string | null | undefined;
+  emailVerified: boolean | undefined;
+}
+
+export default function EditEmailAnimation({
+  editEmailMenu,
+  existingEmail,
+  emailVerified,
+}: EditEmailAnimationProps) {
+  const nodeRef = useRef(null);
+  return (
+    <CSSTransition
+      in={editEmailMenu.value === 'editEmail'}
+      timeout={100}
+      classNames="infoBox"
+      unmountOnExit
+      nodeRef={nodeRef}
+    >
+      <EditEmail
+        existingEmail={existingEmail}
+        emailVerified={emailVerified}
+        editEmailMenu={editEmailMenu}
+      />
+    </CSSTransition>
+  );
+}

--- a/src/components/Menus/EditEmail/EditEmail.styled.ts
+++ b/src/components/Menus/EditEmail/EditEmail.styled.ts
@@ -1,0 +1,78 @@
+import styled from 'styled-components';
+import { StyledMiddleScreenMenu } from '../Layouts/MiddleScreenMenu/MiddleScreenMenu.styled';
+
+export const StyledEditEmail = styled(StyledMiddleScreenMenu)`
+  .title {
+    font-size: 18px;
+    font-weight: 600;
+    color: ${({ theme }) => theme.lightColor};
+  }
+
+  .current {
+    font-size: 14px;
+    color: ${({ theme }) => theme.lightColor};
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .badge {
+    display: inline-block;
+    align-self: flex-start;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .badge.verified {
+    background-color: ${({ theme }) => theme.green};
+    color: black;
+  }
+
+  .badge.unverified {
+    background-color: ${({ theme }) => theme.redish};
+    color: white;
+    cursor: pointer;
+  }
+
+  .description {
+    font-size: 14px;
+    color: ${({ theme }) => theme.lightColor};
+    white-space: initial;
+  }
+
+  .errormsg {
+    font-size: 12px;
+    color: ${({ theme }) => theme.redish};
+    white-space: initial;
+  }
+
+  .input {
+    border-radius: 10px;
+    padding: 0.8rem;
+    outline: none;
+    color: white;
+    background-color: ${({ theme }) => theme.layer2};
+    border-style: none;
+    font-size: 18px;
+  }
+
+  .resend {
+    background: none;
+    border: none;
+    padding: 0;
+    color: ${({ theme }) => theme.lightColor};
+    text-decoration: underline;
+    cursor: pointer;
+    align-self: flex-start;
+    font-size: 14px;
+  }
+
+  .buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    gap: 10px;
+  }
+`;

--- a/src/components/Menus/EditEmail/EditEmail.tsx
+++ b/src/components/Menus/EditEmail/EditEmail.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react';
+import { Signal } from '@preact/signals-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { setAccountEmail, verifyAccountEmail } from '../../../api/auth/api';
+import {
+  SetAccountEmailRequest,
+  VerifyAccountEmailRequest,
+} from '../../../types';
+import MyButton from '../../MyButton/MyButton';
+import { StyledEditEmail } from './EditEmail.styled';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface EditEmailProps {
+  existingEmail: string | null | undefined;
+  emailVerified: boolean | undefined;
+  editEmailMenu: Signal<string | null>;
+}
+
+type Step = 'view' | 'edit' | 'verify';
+
+export default function EditEmail({
+  existingEmail,
+  emailVerified,
+  editEmailMenu,
+}: EditEmailProps) {
+  const queryClient = useQueryClient();
+  const initialStep: Step = existingEmail ? 'view' : 'edit';
+
+  const [step, setStep] = useState<Step>(initialStep);
+  const [email, setEmail] = useState(existingEmail ?? '');
+  const [pendingEmail, setPendingEmail] = useState<string>(existingEmail ?? '');
+  const [emailError, setEmailError] = useState('');
+  const [code, setCode] = useState('');
+  const [codeError, setCodeError] = useState('');
+
+  const setEmailMutation = useMutation<void, any, SetAccountEmailRequest>({
+    mutationFn: setAccountEmail,
+  });
+
+  const verifyMutation = useMutation<void, any, VerifyAccountEmailRequest>({
+    mutationFn: verifyAccountEmail,
+  });
+
+  const handleSetEmail = () => {
+    if (!email || !EMAIL_REGEX.test(email)) {
+      setEmailError('Please enter a valid email address');
+      return;
+    }
+    setEmailError('');
+    setEmailMutation.mutate(
+      { email },
+      {
+        onSuccess: () => {
+          setPendingEmail(email);
+          setCode('');
+          setCodeError('');
+          setStep('verify');
+        },
+        onError: (error) => {
+          const message =
+            error?.response?.data?.message ||
+            error?.response?.data ||
+            'Failed to set email. Please try again.';
+          setEmailError(
+            typeof message === 'string' ? message : 'Failed to set email.'
+          );
+        },
+      }
+    );
+  };
+
+  const handleVerify = () => {
+    if (!/^\d{6}$/.test(code)) {
+      setCodeError('Enter the 6-digit code from your email');
+      return;
+    }
+    setCodeError('');
+    verifyMutation.mutate(
+      { code },
+      {
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({ queryKey: ['getMe'] });
+          editEmailMenu.value = null;
+        },
+        onError: () => {
+          setCodeError('Invalid or expired code. Please try again.');
+        },
+      }
+    );
+  };
+
+  const handleResend = () => {
+    if (!pendingEmail) return;
+    setCodeError('');
+    setEmailMutation.mutate({ email: pendingEmail });
+  };
+
+  const handleCancel = () => {
+    editEmailMenu.value = null;
+  };
+
+  const handleVerifyNow = () => {
+    if (!existingEmail) return;
+    setPendingEmail(existingEmail);
+    setCode('');
+    setCodeError('');
+    setEmailMutation.mutate({ email: existingEmail });
+    setStep('verify');
+  };
+
+  if (step === 'view') {
+    return (
+      <StyledEditEmail>
+        <div className="title">Email</div>
+        <div className="current">
+          <div>{existingEmail || 'Not set'}</div>
+          {existingEmail ? (
+            emailVerified ? (
+              <span className="badge verified">Verified</span>
+            ) : (
+              <span className="badge unverified" onClick={handleVerifyNow}>
+                Unverified — verify now
+              </span>
+            )
+          ) : null}
+        </div>
+        <div className="buttons">
+          <MyButton onClick={() => setStep('edit')}>
+            {existingEmail ? 'Change' : 'Set email'}
+          </MyButton>
+          <MyButton variant="secondary" onClick={handleCancel}>
+            Close
+          </MyButton>
+        </div>
+      </StyledEditEmail>
+    );
+  }
+
+  if (step === 'edit') {
+    return (
+      <StyledEditEmail>
+        <div className="title">
+          {existingEmail ? 'Change email' : 'Set email'}
+        </div>
+        <input
+          type="email"
+          inputMode="email"
+          className="input"
+          placeholder="your@email.com"
+          value={email}
+          autoFocus
+          onChange={(e) => {
+            setEmailError('');
+            setEmail(e.target.value);
+          }}
+        />
+        {emailError && <div className="errormsg">{emailError}</div>}
+        <div className="buttons">
+          <MyButton
+            onClick={handleSetEmail}
+            isLoading={setEmailMutation.isPending}
+          >
+            Continue
+          </MyButton>
+          <MyButton variant="secondary" onClick={handleCancel}>
+            Cancel
+          </MyButton>
+        </div>
+      </StyledEditEmail>
+    );
+  }
+
+  return (
+    <StyledEditEmail>
+      <div className="title">Verify email</div>
+      <div className="description">
+        We sent a 6-digit code to {pendingEmail}. Enter it below to verify your
+        email.
+      </div>
+      <input
+        type="text"
+        inputMode="numeric"
+        maxLength={6}
+        className="input"
+        placeholder="6-digit code"
+        value={code}
+        autoFocus
+        onChange={(e) => {
+          setCodeError('');
+          setCode(e.target.value.replace(/\D/g, '').slice(0, 6));
+        }}
+      />
+      {codeError && <div className="errormsg">{codeError}</div>}
+      <button
+        type="button"
+        className="resend"
+        onClick={handleResend}
+        disabled={setEmailMutation.isPending}
+      >
+        {setEmailMutation.isPending ? 'Resending…' : 'Resend code'}
+      </button>
+      <div className="buttons">
+        <MyButton onClick={handleVerify} isLoading={verifyMutation.isPending}>
+          Verify
+        </MyButton>
+        <MyButton variant="secondary" onClick={handleCancel}>
+          Cancel
+        </MyButton>
+      </div>
+    </StyledEditEmail>
+  );
+}

--- a/src/components/Menus/ForgotCredentials/ForgotCredentials.styled.ts
+++ b/src/components/Menus/ForgotCredentials/ForgotCredentials.styled.ts
@@ -1,0 +1,60 @@
+import styled from 'styled-components';
+import { StyledMiddleScreenMenu } from '../Layouts/MiddleScreenMenu/MiddleScreenMenu.styled';
+
+export const StyledForgotCredentials = styled(StyledMiddleScreenMenu)`
+  .title {
+    font-size: 18px;
+    font-weight: 600;
+    color: ${({ theme }) => theme.lightColor};
+  }
+
+  .description {
+    font-size: 14px;
+    color: ${({ theme }) => theme.lightColor};
+    white-space: initial;
+  }
+
+  .errormsg {
+    font-size: 12px;
+    color: ${({ theme }) => theme.redish};
+    white-space: initial;
+  }
+
+  .confirmation {
+    font-size: 14px;
+    color: ${({ theme }) => theme.lightColor};
+    white-space: initial;
+  }
+
+  .buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    gap: 10px;
+  }
+`;
+
+export const StyledForgotBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 998;
+`;
+
+export const StyledForgotLinks = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 15px;
+  font-size: 14px;
+
+  .link {
+    color: ${({ theme }) => theme.lightColor};
+    text-decoration: underline;
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 14px;
+  }
+`;

--- a/src/components/Menus/ForgotCredentials/ForgotCredentials.tsx
+++ b/src/components/Menus/ForgotCredentials/ForgotCredentials.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import {
+  StyledForgotBackdrop,
+  StyledForgotCredentials,
+} from './ForgotCredentials.styled';
+import Input from '../../Input/Input';
+import MyButton from '../../MyButton/MyButton';
+import {
+  requestPasswordReset,
+  requestUsernameRecovery,
+} from '../../../api/auth/api';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const GENERIC_CONFIRMATION =
+  "If that email is registered, we've sent instructions.";
+
+interface ForgotCredentialsProps {
+  mode: 'password' | 'username';
+  onClose: () => void;
+}
+
+export default function ForgotCredentials({
+  mode,
+  onClose,
+}: ForgotCredentialsProps) {
+  const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const { mutate: forgotMutation, isPending } = useMutation({
+    mutationFn:
+      mode === 'password' ? requestPasswordReset : requestUsernameRecovery,
+  });
+
+  const title =
+    mode === 'password' ? 'Forgot password?' : 'Forgot username?';
+  const description =
+    mode === 'password'
+      ? 'Enter the email associated with your account and we will send you a password reset link.'
+      : 'Enter the email associated with your account and we will send you your username.';
+
+  const handleSubmit = () => {
+    if (submitted) return;
+    if (!email || !EMAIL_REGEX.test(email)) {
+      setEmailError('Please enter a valid email address');
+      return;
+    }
+    setEmailError('');
+    forgotMutation(
+      { email },
+      {
+        onSettled: () => {
+          setSubmitted(true);
+        },
+      }
+    );
+  };
+
+  return (
+    <>
+      <StyledForgotBackdrop onClick={onClose} />
+      <StyledForgotCredentials>
+        <div className="title">{title}</div>
+        {submitted ? (
+          <>
+            <div className="confirmation">{GENERIC_CONFIRMATION}</div>
+            <div className="buttons">
+              <MyButton onClick={onClose}>Close</MyButton>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="description">{description}</div>
+            <Input
+              type="email"
+              inputMode="email"
+              placeholder="Email"
+              value={email}
+              error={emailError ? true : false}
+              onChange={(e) => {
+                setEmailError('');
+                setEmail(e.target.value);
+              }}
+              autoFocus={true}
+            />
+            {emailError && <div className="errormsg">{emailError}</div>}
+            <div className="buttons">
+              <MyButton onClick={handleSubmit} isLoading={isPending}>
+                Submit
+              </MyButton>
+              <MyButton variant="secondary" onClick={onClose}>
+                Cancel
+              </MyButton>
+            </div>
+          </>
+        )}
+      </StyledForgotCredentials>
+    </>
+  );
+}

--- a/src/components/Menus/SettingsMenu/SettingsMenu.tsx
+++ b/src/components/Menus/SettingsMenu/SettingsMenu.tsx
@@ -24,7 +24,9 @@ import { useTimeZone } from '../../../api/auth/CommandHooks/useTimeZone';
 import { getInitials } from '../../../helpers/getInitials';
 import { timeZones } from '../../../helpers/timeZones';
 import EditUsernameAnimation from '../../Animations/EditUsernameAnimation';
+import EditEmailAnimation from '../../Animations/EditEmailAnimation';
 import { FaUserPen } from 'react-icons/fa6';
+import { MdOutlineEmail } from 'react-icons/md';
 import { useSetShowBudgetInfo } from '@/api/auth/CommandHooks/useSetShowBudgetInfo';
 
 export default function SettingsMenu({
@@ -37,6 +39,7 @@ export default function SettingsMenu({
   const currencyMenu = useSignal<string | null>(null);
   const timeZoneMenu = useSignal<string | null>(null);
   const editUsernameMenu = useSignal<string | null>(null);
+  const editEmailMenu = useSignal<string | null>(null);
 
   const queryClient = useQueryClient();
 
@@ -144,6 +147,21 @@ export default function SettingsMenu({
           <div className="description">Change username</div>
         </div>
 
+        <div
+          className="option"
+          onClick={() => (editEmailMenu.value = 'editEmail')}
+        >
+          <MdOutlineEmail className="icon" />
+          <div className="description">
+            Email{' '}
+            {userInfo?.email
+              ? userInfo.emailVerified
+                ? '(Verified)'
+                : '(Unverified)'
+              : '(Not set)'}
+          </div>
+        </div>
+
         <div className="option" onClick={handleLogout}>
           <TbLogout2 className="icon" />
           <div className="description">Log out</div>
@@ -156,6 +174,7 @@ export default function SettingsMenu({
       <MenuAnimationBackground menu={currencyMenu} />
       <MenuAnimationBackground menu={timeZoneMenu} />
       <MenuAnimationBackground menu={editUsernameMenu} />
+      <MenuAnimationBackground menu={editEmailMenu} />
       <TimeZoneOptionsAnimation
         timeZoneMenu={timeZoneMenu}
         clickHandler={handldeTimeZoneOptionsClick}
@@ -169,6 +188,11 @@ export default function SettingsMenu({
       <EditUsernameAnimation
         editUsernameMenu={editUsernameMenu}
         existingUsername={userInfo?.username}
+      />
+      <EditEmailAnimation
+        editEmailMenu={editEmailMenu}
+        existingEmail={userInfo?.email}
+        emailVerified={userInfo?.emailVerified}
       />
     </StyledSettingsMenu>
   );

--- a/src/pages/Auth/AuthPage.tsx
+++ b/src/pages/Auth/AuthPage.tsx
@@ -9,17 +9,23 @@ import WelcomeHeader from './WelcomeHeader/WelcomeHeader';
 import Input from '../../components/Input/Input';
 import { sendPasswordCredentials } from '../../api/auth/api';
 import MyButton from '../../components/MyButton/MyButton';
+import ForgotCredentials from '../../components/Menus/ForgotCredentials/ForgotCredentials';
+import { StyledForgotLinks } from '../../components/Menus/ForgotCredentials/ForgotCredentials.styled';
 
 const AuthPage: React.FC = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [networkError, setNetworkError] = useState<string>('');
   const [requestError, setRequestError] = useState<string>('');
+  const [forgotMode, setForgotMode] = useState<'password' | 'username' | null>(
+    null
+  );
   const navigate = useNavigate();
   const location = useLocation();
 
-  const redirect =
-    new URLSearchParams(location.search).get('redirect') || routes.ROOT;
+  const searchParams = new URLSearchParams(location.search);
+  const redirect = searchParams.get('redirect') || routes.ROOT;
+  const successMessage = searchParams.get('message') || '';
 
   const { mutate: signInWithCredentialsMutation, isPending } = useMutation<
     PasswordSignInResponse,
@@ -58,7 +64,11 @@ const AuthPage: React.FC = () => {
     <StyledAuthPage>
       <WelcomeHeader />
       <div className="loginBox">
-        {/* <div className="promptMsg">Enter username and password to sign in.</div> */}
+        {successMessage ? (
+          <div className="promptMsg">{successMessage}</div>
+        ) : (
+          ''
+        )}
         <div className="controlsContainer">
           <div className="inputBox">
             <Input
@@ -91,6 +101,23 @@ const AuthPage: React.FC = () => {
             {/* <div className="mailmsg">{signInError}&nbsp;</div> */}
           </div>
 
+          <StyledForgotLinks>
+            <button
+              type="button"
+              className="link"
+              onClick={() => setForgotMode('password')}
+            >
+              Forgot password?
+            </button>
+            <button
+              type="button"
+              className="link"
+              onClick={() => setForgotMode('username')}
+            >
+              Forgot username?
+            </button>
+          </StyledForgotLinks>
+
           <div className="createAccountSignIn">
             <MyButton
               onClick={handleSignIn}
@@ -110,6 +137,12 @@ const AuthPage: React.FC = () => {
           <div className="errormsg">{networkError}</div>
         </div>
       </div>
+      {forgotMode && (
+        <ForgotCredentials
+          mode={forgotMode}
+          onClose={() => setForgotMode(null)}
+        />
+      )}
     </StyledAuthPage>
   );
 };

--- a/src/pages/CreateAccount/CreateAccount.tsx
+++ b/src/pages/CreateAccount/CreateAccount.tsx
@@ -9,11 +9,15 @@ import { createPasswordCredentials } from '../../api/auth/api';
 import { PasswordSignUpRequest, PasswordSignUpResponse } from '../../types';
 import routes from '../../routes';
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export default function CreateAccount() {
   const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [networkError, setNetworkError] = useState<string>('');
   const [requestError, setRequestError] = useState<string>('');
+  const [emailError, setEmailError] = useState<string>('');
   const [passwordError, setPasswordError] = useState<string>('');
   const navigate = useNavigate();
 
@@ -29,17 +33,27 @@ export default function CreateAccount() {
   });
 
   const handleSignUp = () => {
+    if (!username) return;
+    if (!email) {
+      setEmailError('Email is required');
+      return;
+    }
+    if (!EMAIL_REGEX.test(email)) {
+      setEmailError('Please enter a valid email address');
+      return;
+    }
     if (password.length < 9) {
       setPasswordError('Password should contain at least 10 characters');
       return;
     }
-    if (!username || !password) return;
+    if (!password) return;
     setNetworkError('');
     setRequestError('');
+    setEmailError('');
     setPasswordError('');
 
     signUpWithCredentialsMutation(
-      { username, password },
+      { username, password, email },
       {
         onSuccess: (response) => {
           localStorage.setItem('accessToken', response.accessToken);
@@ -80,6 +94,24 @@ export default function CreateAccount() {
             />
             {requestError ? (
               <div className="errormsg">{requestError}&nbsp;</div>
+            ) : (
+              ''
+            )}
+          </div>
+          <div className="inputBox">
+            <Input
+              type="email"
+              inputMode="email"
+              value={email}
+              error={emailError ? true : false}
+              placeholder="Email"
+              onChange={(e) => {
+                setEmailError('');
+                setEmail(e.target.value);
+              }}
+            />
+            {emailError ? (
+              <div className="errormsg">{emailError}&nbsp;</div>
             ) : (
               ''
             )}

--- a/src/pages/ResetPassword/ResetPassword.styled.ts
+++ b/src/pages/ResetPassword/ResetPassword.styled.ts
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+export const StyledResetPassword = styled.div`
+  margin: 0rem 2rem 0rem 2rem;
+  display: flex;
+  flex-direction: column;
+  color: ${({ theme }) => theme.lightColor};
+
+  .loginBox {
+    padding: 1rem 0.8rem;
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    background-color: ${({ theme }) => theme.layer1};
+    border-color: ${({ theme }) => theme.layer1};
+    border-style: 'solid';
+
+    .promptMsg {
+      display: flex;
+      justify-content: center;
+      color: ${({ theme }) => theme.lightColor};
+      padding-bottom: 1rem;
+      white-space: initial;
+      font-size: 18px;
+    }
+    .controlsContainer {
+      display: flex;
+      flex-direction: column;
+
+      .errormsg {
+        white-space: initial;
+        color: ${({ theme }) => theme.redish};
+        font-size: 12px;
+      }
+
+      .inputBox {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 15px;
+      }
+    }
+  }
+`;

--- a/src/pages/ResetPassword/ResetPassword.tsx
+++ b/src/pages/ResetPassword/ResetPassword.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { resetPassword } from '../../api/auth/api';
+import { ResetPasswordRequest } from '../../types';
+import routes from '../../routes';
+import Input from '../../components/Input/Input';
+import MyButton from '../../components/MyButton/MyButton';
+import WelcomeHeader from '../Auth/WelcomeHeader/WelcomeHeader';
+import { StyledResetPassword } from './ResetPassword.styled';
+
+export default function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+  const navigate = useNavigate();
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [requestError, setRequestError] = useState('');
+
+  useEffect(() => {
+    if (!token) {
+      navigate(routes.AUTH);
+    }
+  }, [token, navigate]);
+
+  const { mutate: resetPasswordMutation, isPending } = useMutation<
+    void,
+    any,
+    ResetPasswordRequest
+  >({
+    mutationFn: resetPassword,
+  });
+
+  const handleSubmit = () => {
+    if (!token) return;
+    if (newPassword.length < 10) {
+      setError('Password should contain at least 10 characters');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+    setError('');
+    setRequestError('');
+
+    resetPasswordMutation(
+      { token, newPassword },
+      {
+        onSuccess: () => {
+          navigate(
+            `${routes.AUTH}?message=${encodeURIComponent(
+              'Password updated, please sign in.'
+            )}`
+          );
+        },
+        onError: () => {
+          setRequestError('This reset link is invalid or has expired.');
+        },
+      }
+    );
+  };
+
+  if (!token) return null;
+
+  return (
+    <StyledResetPassword>
+      <WelcomeHeader />
+      <div className="loginBox">
+        <div className="promptMsg">Reset your password</div>
+        <div className="controlsContainer">
+          <div className="inputBox">
+            <Input
+              type="password"
+              value={newPassword}
+              error={error ? true : false}
+              placeholder="New Password"
+              onChange={(e) => {
+                setError('');
+                setRequestError('');
+                setNewPassword(e.target.value);
+              }}
+            />
+          </div>
+          <div className="inputBox">
+            <Input
+              type="password"
+              value={confirmPassword}
+              error={error ? true : false}
+              placeholder="Confirm Password"
+              onChange={(e) => {
+                setError('');
+                setRequestError('');
+                setConfirmPassword(e.target.value);
+              }}
+            />
+            {error ? <div className="errormsg">{error}</div> : ''}
+          </div>
+
+          <MyButton fontSize="18" onClick={handleSubmit} isLoading={isPending}>
+            Reset Password
+          </MyButton>
+          {requestError ? (
+            <div className="errormsg">{requestError}</div>
+          ) : (
+            ''
+          )}
+        </div>
+      </div>
+    </StyledResetPassword>
+  );
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,6 +4,7 @@ const routes = {
   AUTH: '/welcome',
   CREATE: '/entry',
   GOOGLE_REDIRECT: '/google/redirect',
+  RESET_PASSWORD: '/reset-password',
   USER_INVITATIONS: '/invitations',
   JOIN: '/j/:code',
   GROUP: '/shared/:groupid',

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,10 +17,32 @@ export type PasswordSignInResponse = {
 export type PasswordSignUpRequest = {
   username: string;
   password: string;
+  email: string;
 };
 
 export type PasswordSignUpResponse = {
   accessToken: string;
+};
+
+export type RequestPasswordResetRequest = {
+  email: string;
+};
+
+export type ResetPasswordRequest = {
+  token: string;
+  newPassword: string;
+};
+
+export type RequestUsernameRecoveryRequest = {
+  email: string;
+};
+
+export type SetAccountEmailRequest = {
+  email: string;
+};
+
+export type VerifyAccountEmailRequest = {
+  code: string;
 };
 
 export type SendGoogleCodeRequest = {
@@ -40,6 +62,8 @@ export type UserInfo = {
   hasNewerNotifications: boolean;
   currency: string;
   showBudgetInfo: boolean;
+  email: string | null;
+  emailVerified: boolean;
 };
 
 export type ExpenseItem = {


### PR DESCRIPTION
Implements #204 — frontend side of email collection and account-recovery.

## Summary
- Sign-up now collects an email (regex-validated).
- "Forgot password?" / "Forgot username?" links on the sign-in page (shared modal, generic confirmation copy).
- New public `/reset-password?token=...` route + page.
- Settings → Email row with set/change + 6-digit verification flow + Resend code.
- New auth API wrappers and types; `UserInfo` extended with `email` / `emailVerified`.

## Test plan
- [ ] Sign up requires a valid email; duplicate email backend error renders.
- [ ] Forgot links always show the same generic confirmation copy.
- [ ] `/reset-password?token=...` resets password and returns to /welcome with success message.
- [ ] Settings → Email: user with `email==null` can set then verify.
- [ ] After verify success the badge flips to Verified without a reload.
- [ ] Existing sign-in / sign-up / Google flows still work.

Generated with [Claude Code](https://claude.ai/code)