### PR TITLE
Enable manual trigger for code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,12 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'The Pull Request number to review'
+        required: true
+        type: string
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"


### PR DESCRIPTION
Added workflow_dispatch to allow manual triggering with PR number input.